### PR TITLE
Support Postgresql 9.4 jsonb column type

### DIFF
--- a/lib/flex_columns/definition/flex_column_contents_class.rb
+++ b/lib/flex_columns/definition/flex_column_contents_class.rb
@@ -26,6 +26,7 @@ module FlexColumns
 
         storage = case column.type
         when :binary, :text, :json then column.type
+        when :jsonb then :json
         when :string then :text
         else raise "Unknown storage type: #{column.type.inspect}"
         end
@@ -297,6 +298,8 @@ That column is of type: #{out.type.inspect}.}
         if column.type == :binary || column.type == :text || column.type == :string
           true
         elsif column.sql_type == "json" # for PostgreSQL >= 9.2, which has a native JSON data type
+          true
+        elsif column.sql_type == "jsonb" # for PostgreSQL >= 9.4, which has a native JSONB data type
           true
         else
           false


### PR DESCRIPTION
Difference between jsonb and json column types is only internal. All input accepted by json is also accepted by jsonb.

For more details, see: http://www.postgresql.org/message-id/E1WRpmB-0002et-MT@gemulon.postgresql.org
